### PR TITLE
Change memlock limit

### DIFF
--- a/hosts/adsl-ssd/default.nix
+++ b/hosts/adsl-ssd/default.nix
@@ -61,4 +61,8 @@
   };
 
   networking.firewall.allowedTCPPorts = [ 2201 ];
+
+  security.pam.loginLimits = [
+    { domain = "proteet"; type = "soft"; item = "memlock"; value = "unlimited"; }
+  ];
 }

--- a/hosts/common/proteet.nix
+++ b/hosts/common/proteet.nix
@@ -10,8 +10,8 @@
     description = "Proteet Paul";
     extraGroups = [
       "docker"
-      "wheel",
-      "disk",
+      "wheel"
+      "disk"
     ];
     openssh.authorizedKeys.keys = [
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKDqaQHnz1TEdQvpUHgF1kXoCV0dNRauso/Z7toJBg05 Access to ADSL ssd"

--- a/hosts/common/proteet.nix
+++ b/hosts/common/proteet.nix
@@ -1,0 +1,20 @@
+{
+  pkgs,
+  ...
+}: {
+  programs.bash.enable = true;
+  users.users.proteet = {
+    isNormalUser = true;
+    uid = 1002;
+    shell = pkgs.bash;
+    description = "Proteet Paul";
+    extraGroups = [
+      "docker"
+      "wheel",
+      "disk",
+    ];
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKDqaQHnz1TEdQvpUHgF1kXoCV0dNRauso/Z7toJBg05 Access to ADSL ssd"
+    ];
+  };
+}

--- a/programs/accounts/proteet.nix
+++ b/programs/accounts/proteet.nix
@@ -1,0 +1,30 @@
+{ lib, pkgs, ... }: {
+  programs.tmux = {
+    shell = "${pkgs.bash}/bin/bash";
+  };
+  home = {
+    username = "proteet";
+    homeDirectory = "/home/proteet";
+  };
+
+  home.packages = with pkgs; [
+    unzip
+    fio
+    cmake
+    libgcc
+    bcc
+    liburing
+    spdk
+    rustc
+    cargo
+    htop
+    tmux
+  ];
+
+  programs.git = {
+    enable = true;
+    userName = "proteetpaul";
+    userEmail = "proteetpaul@gmail.com";
+  };
+
+}


### PR DESCRIPTION
Avoid limits on memory pinning for testing of fixed buffers using io-uring. Default is 8192 bytes.